### PR TITLE
Improved interface with logging options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,10 @@
+# wai-log-0.2 (not released)
+
+* Entire interface has changed: now builds a `Middleware` in a `MonadLog`
+  context
+* Adds `Options` to control what is logged
+* Currently logging behaviour is unchanged when using `defaultOptions`
+
 # wai-log-0.1 (2019-03-07)
+
 * Initial release (split from internal Scrive package).

--- a/src/Network/Wai/Log.hs
+++ b/src/Network/Wai/Log.hs
@@ -1,8 +1,7 @@
 -- | A simple logging middleware for WAI applications that supports the 'log-*'
 -- family of packages: <https://hackage.haskell.org/package/log-base>
 --
--- Currently there are no logging options but contributions are welcome.
--- When logging to @stdout@, the output looks like this:
+-- When logging to @stdout@ using 'defaultOptions', the output looks like this:
 --
 -- @
 -- 2019-02-21 19:51:47 INFO my-server: Request received {
@@ -29,7 +28,8 @@ module Network.Wai.Log (
   mkApplicationLogger
 , mkApplicationLoggerWith
 -- ** Options
-, module Network.Wai.Log.Options
+, Options(..)
+, defaultOptions
 ) where
 
 import Prelude hiding (log)

--- a/src/Network/Wai/Log/Internal.hs
+++ b/src/Network/Wai/Log/Internal.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE RecordWildCards #-}
+module Network.Wai.Log.Internal where
+
+import Control.Monad (when)
+import Data.Aeson.Types (Value, object, emptyObject)
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime, getCurrentTime)
+import Log (LogLevel)
+import Network.Wai (Middleware)
+
+import Network.Wai.Log.Options (Options(..))
+
+-- | This type matches the one returned by 'getLoggerIO'
+type LoggerIO = UTCTime -> LogLevel -> Text -> Value -> IO ()
+
+-- | Create a logging 'Middleware' given a 'LoggerIO' logging function and 'Options'
+logRequestsWith :: LoggerIO -> Options -> Middleware
+logRequestsWith loggerIO Options{..} app req respond = do
+  logIO "Request received" . object . logRequest $ req
+  tStart <- getCurrentTime
+  app req $ \resp -> do
+    tEnd <- getCurrentTime
+    when logSendingResponse $
+         logIO_ "Sending response"
+    r <- respond resp
+    tFull <- getCurrentTime
+    logIO "Request complete" . object $
+      logResponse resp tStart tEnd tFull
+    return r
+
+  where
+
+    logIO message value = do
+      now <- getCurrentTime
+      loggerIO now logLevel message value
+
+    logIO_ m = logIO m emptyObject

--- a/src/Network/Wai/Log/Internal.hs
+++ b/src/Network/Wai/Log/Internal.hs
@@ -24,8 +24,8 @@ logRequestsWith loggerIO Options{..} app req respond = do
          logIO_ "Sending response"
     r <- respond resp
     tFull <- getCurrentTime
-    let processing = diffUTCTime tStart tEnd
-        full       = diffUTCTime tStart tFull
+    let processing = diffUTCTime tEnd  tStart
+        full       = diffUTCTime tFull tStart
         times      = ResponseTime{..}
     logIO "Request complete" . object $ logResponse resp times
     return r

--- a/src/Network/Wai/Log/Internal.hs
+++ b/src/Network/Wai/Log/Internal.hs
@@ -27,7 +27,7 @@ logRequestsWith loggerIO Options{..} app req respond = do
     let processing = diffUTCTime tEnd  tStart
         full       = diffUTCTime tFull tStart
         times      = ResponseTime{..}
-    logIO "Request complete" . object $ logResponse resp times
+    logIO "Request complete" . object $ logResponse req resp times
     return r
 
   where

--- a/src/Network/Wai/Log/Options.hs
+++ b/src/Network/Wai/Log/Options.hs
@@ -1,8 +1,9 @@
 module Network.Wai.Log.Options (
+-- * Options
   Options(..)
+-- * Defaults
 , defaultOptions
--- * TODO
-, defaultLogRquest
+, defaultLogRequest
 , defaultLogResponse
 ) where
 
@@ -27,28 +28,29 @@ data Options = Options {
 -- | Default 'Options'
 --
 -- @
--- { logLevel = LogInfo
--- , logRequest = defaultLogRquest
+-- { logLevel = 'LogInfo'
+-- , logRequest = 'defaultLogRequest'
 -- , logSendingResponse = True
--- , logResponse = defaultLogResponse
+-- , logResponse = 'defaultLogResponse'
 -- }
 -- @
 defaultOptions :: Options
 defaultOptions = Options
   { logLevel = LogInfo
-  , logRequest = defaultLogRquest
+  , logRequest = defaultLogRequest
   , logSendingResponse = True
   , logResponse = defaultLogResponse
   }
 
 -- | Logs the following request values:
+--
 -- * method
 -- * url path
 -- * remote host
 -- * user agent
 -- * body-length
-defaultLogRquest :: Request -> [Pair]
-defaultLogRquest req =
+defaultLogRequest :: Request -> [Pair]
+defaultLogRequest req =
   [ "method"      .= ts (requestMethod req)
   , "url"         .= ts (rawPathInfo req)
   , "remote-host" .= show (remoteHost req)
@@ -57,6 +59,7 @@ defaultLogRquest req =
   ]
 
 -- | Logs the following values for the response:
+--
 -- * status code
 -- * status message
 --

--- a/src/Network/Wai/Log/Options.hs
+++ b/src/Network/Wai/Log/Options.hs
@@ -1,0 +1,83 @@
+module Network.Wai.Log.Options (
+  Options(..)
+, defaultOptions
+-- * TODO
+, defaultLogRquest
+, defaultLogResponse
+) where
+
+import Data.Aeson.Types (Pair)
+import Data.String.Conversions (ConvertibleStrings, StrictText, cs)
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime, diffUTCTime)
+import Log
+import Network.HTTP.Types.Status
+import Network.Wai
+
+-- | Logging options
+data Options = Options {
+    logLevel            :: LogLevel
+  , logRequest          :: Request -> [Pair]
+  , logSendingResponse  :: Bool
+  -- | The 'UTCTime' values in order are : start, end, full
+  , logResponse         :: Response -> UTCTime -> UTCTime -> UTCTime -> [Pair]
+  -- FIXME: ^ create custom 'Timings' type instead of this "mess"
+  }
+
+-- | Default 'Options'
+--
+-- @
+-- { logLevel = LogInfo
+-- , logRequest = defaultLogRquest
+-- , logSendingResponse = True
+-- , logResponse = defaultLogResponse
+-- }
+-- @
+defaultOptions :: Options
+defaultOptions = Options
+  { logLevel = LogInfo
+  , logRequest = defaultLogRquest
+  , logSendingResponse = True
+  , logResponse = defaultLogResponse
+  }
+
+-- | Logs the following request values:
+-- * method
+-- * url path
+-- * remote host
+-- * user agent
+-- * body-length
+defaultLogRquest :: Request -> [Pair]
+defaultLogRquest req =
+  [ "method"      .= ts (requestMethod req)
+  , "url"         .= ts (rawPathInfo req)
+  , "remote-host" .= show (remoteHost req)
+  , "user-agent"  .= fmap ts (requestHeaderUserAgent req)
+  , "body-length" .= show (requestBodyLength req)
+  ]
+
+-- | Logs the following values for the response:
+-- * status code
+-- * status message
+--
+-- Also logs the "process" and "full" time
+defaultLogResponse
+  :: Response
+  -> UTCTime -- ^ Start time
+  -> UTCTime -- ^ Processing end time
+  -> UTCTime -- ^ Full end time
+  -> [Pair]
+defaultLogResponse resp tStart tEnd tFull =
+    [ "status" .= object [ "code"    .= statusCode (responseStatus resp)
+                         , "message" .= ts (statusMessage (responseStatus resp))
+                         ]
+    , "time"   .= object [ "full"    .= diffSeconds tFull tStart
+                         , "process" .= diffSeconds tEnd tStart
+                         ]
+    ]
+
+diffSeconds :: UTCTime -> UTCTime -> Double
+diffSeconds a b = realToFrac $ diffUTCTime a b
+
+ts :: ConvertibleStrings a StrictText => a -> Text
+ts = cs

--- a/src/Network/Wai/Log/Options.hs
+++ b/src/Network/Wai/Log/Options.hs
@@ -21,7 +21,7 @@ data Options = Options {
     logLevel            :: LogLevel
   , logRequest          :: Request -> [Pair]
   , logSendingResponse  :: Bool
-  , logResponse         :: Response -> ResponseTime -> [Pair]
+  , logResponse         :: Request -> Response -> ResponseTime -> [Pair]
   }
 
 -- | Timing data
@@ -72,9 +72,11 @@ defaultLogRequest req =
 -- * time full
 -- * time processing
 --
+-- Nothing from the 'Request' is logged
+--
 -- Time is in seconds as that is how 'NominalDiffTime' is treated by default
-defaultLogResponse :: Response -> ResponseTime -> [Pair]
-defaultLogResponse resp time =
+defaultLogResponse :: Request -> Response -> ResponseTime -> [Pair]
+defaultLogResponse _req resp time =
     [ "status" .= object [ "code"    .= statusCode (responseStatus resp)
                          , "message" .= ts (statusMessage (responseStatus resp))
                          ]

--- a/src/Network/Wai/Log/Options.hs
+++ b/src/Network/Wai/Log/Options.hs
@@ -78,8 +78,8 @@ defaultLogResponse resp time =
     [ "status" .= object [ "code"    .= statusCode (responseStatus resp)
                          , "message" .= ts (statusMessage (responseStatus resp))
                          ]
-    , "time"   .= object [ "full"       .= full time
-                         , "processing" .= processing time
+    , "time"   .= object [ "full"    .= full time
+                         , "process" .= processing time
                          ]
     ]
 

--- a/wai-log.cabal
+++ b/wai-log.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.0
 name:                wai-log
-version:             0.1.0.0
+version:             0.2.0.0
 
 synopsis:            A logging middleware for WAI applications
 
@@ -45,3 +45,5 @@ library
                      , time
                      , wai
   exposed-modules:     Network.Wai.Log
+                     , Network.Wai.Log.Options
+                     , Network.Wai.Log.Internal


### PR DESCRIPTION
Changes:
* Interface entirely changed
* Now builds a `Middleware` in a `MonadLog` context to avoid passing a `LogT`
* Also some logging `Options` were added
* Logging behaviour is unchanged using `defaultOptions`

TODO:
* [x] Update CHANGELOG