### PR TITLE
Let client decide how `request_id` is generated/parsed

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -13,31 +13,23 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         ghc:
-          - '7.10.3'
-          - '8.0.2'
-          - '8.2.2'
-          - '8.4.4'
-          - '8.6.5'
-          - '8.8.4'
+          - '8.10.7'
+          - '9.2.4'
         experimental: [false]
-        include:
-          - os: ubuntu-latest
-            ghc: '8.10'
-            experimental: true
 
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     name: GHC ${{ matrix.ghc }}
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1
+    - uses: actions/checkout@v3
+    - uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.0'
+        cabal-version: 'latest'
 
     - name: Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       env:
         cache-name: cache-cabal
       with:

--- a/src/Network/Wai/Log.hs
+++ b/src/Network/Wai/Log.hs
@@ -9,11 +9,11 @@
 --   "body_length": "KnownLength 136",
 --   "method": \"POST\",
 --   "user_agent": "curl/7.68.0",
---   "request_uuid": "f2c89425-9ec4-4cd2-ae56-4bab23681fce",
+--   "request_id": "f2c89425-9ec4-4cd2-ae56-4bab23681fce",
 --   "remote_host": "127.0.0.1:34694"
 -- }
 -- 2020-10-27 12:30:23 INFO eid-server: Sending response {
---   "request_uuid": "f2c89425-9ec4-4cd2-ae56-4bab23681fce"
+--   "request_id": "f2c89425-9ec4-4cd2-ae56-4bab23681fce"
 -- }
 -- 2020-10-27 12:30:23 INFO eid-server: Request complete {
 --   "response_body": null,
@@ -27,7 +27,7 @@
 --     "process": 2.97493e-3,
 --     "full": 3.159565e-3
 --   },
---   "request_uuid": "f2c89425-9ec4-4cd2-ae56-4bab23681fce"
+--   "request_id": "f2c89425-9ec4-4cd2-ae56-4bab23681fce"
 -- }
 -- @
 
@@ -44,11 +44,12 @@ module Network.Wai.Log (
 , defaultLogRequest
 , defaultLogResponse
 -- ** Helpers
-, logRequestUUID
+, logRequestId
 ) where
 
 import Prelude hiding (log)
 
+import Data.Aeson (ToJSON)
 import Data.UUID (UUID)
 import Log (MonadLog, getLoggerIO)
 import Network.Wai
@@ -60,18 +61,18 @@ import Network.Wai.Log.Options
 -- that does not work when you want to pass logging context down to the
 -- 'Application'.
 --
--- Instead we pass a 'UUID' to the 'Application', containting the
--- @request_uuid@, so it can be logged in the application's context.
-type LogMiddleware = (UUID -> Application) -> Application
+-- Instead we pass an id to the 'Application', containing the
+-- @request_id@, so it can be logged in the application's context.
+type LogMiddleware id = (id -> Application) -> Application
 
 -- | Create a 'LogMiddleware' using 'defaultOptions'
 --
 -- Use 'mkLogMiddlewareWith' for custom 'Options'
-mkLogMiddleware :: MonadLog m => m LogMiddleware
+mkLogMiddleware :: MonadLog m => m (LogMiddleware UUID)
 mkLogMiddleware = mkLogMiddlewareWith defaultOptions
 
 -- | Create a 'LogMiddleware' using the supplied 'Options'
-mkLogMiddlewareWith :: MonadLog m => Options -> m LogMiddleware
+mkLogMiddlewareWith :: (MonadLog m, ToJSON id) => Options id -> m (LogMiddleware id)
 mkLogMiddlewareWith options = do
   loggerIO <- getLoggerIO
   return $ logRequestsWith loggerIO options

--- a/src/Network/Wai/Log/Internal.hs
+++ b/src/Network/Wai/Log/Internal.hs
@@ -1,30 +1,28 @@
 {-# LANGUAGE RecordWildCards #-}
 module Network.Wai.Log.Internal where
 
-import Data.Aeson.Types (Value(..), object)
+import Data.Aeson.Types (ToJSON, Value(..), object)
 import Data.ByteString.Builder (Builder)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
-import Data.UUID (UUID)
-import Data.UUID.V4 (nextRandom)
 import Log (LogLevel)
 import Network.Wai (Application, responseToStream)
 
-import Network.Wai.Log.Options (Options(..), ResponseTime(..), requestUUID)
+import Network.Wai.Log.Options (Options(..), ResponseTime(..), requestId)
 
 -- | This type matches the one returned by 'getLoggerIO'
 type LoggerIO = UTCTime -> LogLevel -> Text -> Value -> IO ()
 
--- | Create a logging 'Middleware' that takes request UUID
+-- | Create a logging 'Middleware' that takes request id
 -- given a 'LoggerIO' logging function and 'Options'
-logRequestsWith :: LoggerIO -> Options -> (UUID -> Application) -> Application
+logRequestsWith :: ToJSON id => LoggerIO -> Options id -> (id -> Application) -> Application
 logRequestsWith loggerIO Options{..} mkApp req respond = do
-  uuid <- nextRandom
-  logIO "Request received" $ logRequest uuid req
+  reqId <- logGetRequestId req
+  logIO "Request received" $ logRequest reqId req
   tStart <- getCurrentTime
-  mkApp uuid req $ \resp -> do
+  mkApp reqId req $ \resp -> do
     tEnd <- getCurrentTime
-    logIO "Sending response" . requestUUID $ uuid
+    logIO "Sending response" . requestId $ reqId
     r <- respond resp
     tFull <- getCurrentTime
     let processing = diffUTCTime tEnd  tStart
@@ -33,19 +31,19 @@ logRequestsWith loggerIO Options{..} mkApp req respond = do
 
     _ <- case logBody of
       Nothing ->
-        logIO "Request complete" $ logResponse uuid req resp Null times
+        logIO "Request complete" $ logResponse reqId req resp Null times
       Just bodyLogValueConstructorFunction ->
         let (status, responseHeaders, bodyToIO) = responseToStream resp
             mBodyLogValueConstructor =
               bodyLogValueConstructorFunction req status responseHeaders
         in case mBodyLogValueConstructor of
           Nothing ->
-            logIO "Request complete" $ logResponse uuid req resp Null times
+            logIO "Request complete" $ logResponse reqId req resp Null times
           Just bodyLogValueConstructor ->
             bodyToIO $ \streamingBodyToIO ->
               let logWithBuilder :: Builder -> IO ()
                   logWithBuilder b = logIO "Request complete" $
-                    logResponse uuid req resp (bodyLogValueConstructor b) times
+                    logResponse reqId req resp (bodyLogValueConstructor b) times
 
               in streamingBodyToIO logWithBuilder (return ())
     return r


### PR DESCRIPTION
Let client decide how `request_id` is generated/parsed from the request by providing a function field `Request -> IO id` in the `Options` configuration type and make the `request_id` type opaque. Fixes #7 