### PR TITLE
Make the 'Sending Response' log line configurable

### DIFF
--- a/src/Network/Wai/Log.hs
+++ b/src/Network/Wai/Log.hs
@@ -50,7 +50,6 @@ module Network.Wai.Log (
 
 import Prelude hiding (log)
 
-import Data.Aeson (ToJSON)
 import Data.UUID (UUID)
 import Log (MonadLog, getLoggerIO)
 import Network.Wai
@@ -73,7 +72,7 @@ mkLogMiddleware :: MonadLog m => m (LogMiddleware UUID)
 mkLogMiddleware = mkLogMiddlewareWith defaultOptions
 
 -- | Create a 'LogMiddleware' using the supplied 'Options'
-mkLogMiddlewareWith :: (MonadLog m, ToJSON id) => Options id -> m (LogMiddleware id)
+mkLogMiddlewareWith :: (MonadLog m) => Options id -> m (LogMiddleware id)
 mkLogMiddlewareWith options = do
   loggerIO <- getLoggerIO
   return $ logRequestsWith loggerIO options

--- a/src/Network/Wai/Log/Internal.hs
+++ b/src/Network/Wai/Log/Internal.hs
@@ -8,7 +8,7 @@ import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
 import Log (LogLevel)
 import Network.Wai (Application, responseToStream)
 
-import Network.Wai.Log.Options (Options(..), ResponseTime(..), requestId)
+import Network.Wai.Log.Options (Options(..), ResponseTime(..))
 
 -- | This type matches the one returned by 'getLoggerIO'
 type LoggerIO = UTCTime -> LogLevel -> Text -> Value -> IO ()
@@ -22,7 +22,7 @@ logRequestsWith loggerIO Options{..} mkApp req respond = do
   tStart <- getCurrentTime
   mkApp reqId req $ \resp -> do
     tEnd <- getCurrentTime
-    logIO "Sending response" . requestId $ reqId
+    logIO "Sending response" $ logResponseSending reqId req
     r <- respond resp
     tFull <- getCurrentTime
     let processing = diffUTCTime tEnd  tStart

--- a/src/Network/Wai/Log/Internal.hs
+++ b/src/Network/Wai/Log/Internal.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE RecordWildCards #-}
 module Network.Wai.Log.Internal where
 
-import Data.Aeson.Types (ToJSON, Value(..), object)
+import Data.Aeson.Types (Value(..), object)
 import Data.ByteString.Builder (Builder)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime, diffUTCTime, getCurrentTime)
@@ -15,7 +15,7 @@ type LoggerIO = UTCTime -> LogLevel -> Text -> Value -> IO ()
 
 -- | Create a logging 'Middleware' that takes request id
 -- given a 'LoggerIO' logging function and 'Options'
-logRequestsWith :: ToJSON id => LoggerIO -> Options id -> (id -> Application) -> Application
+logRequestsWith :: LoggerIO -> Options id -> (id -> Application) -> Application
 logRequestsWith loggerIO Options{..} mkApp req respond = do
   reqId <- logGetRequestId req
   logIO "Request received" $ logRequest reqId req

--- a/src/Network/Wai/Log/Options.hs
+++ b/src/Network/Wai/Log/Options.hs
@@ -128,7 +128,6 @@ defaultLogResponse reqId req resp responseBody time =
 defaultLogResponseSending :: (ToJSON id) => id -> Request -> [Pair]
 defaultLogResponseSending reqId _req = requestId reqId
 
-
 -- | Helper to consistently log the request id in your application by adding
 -- @request_id@ field to log's 'localData'
 logRequestId :: (MonadLog m, ToJSON id) => id -> m a -> m a

--- a/src/Network/Wai/Log/Options.hs
+++ b/src/Network/Wai/Log/Options.hs
@@ -36,6 +36,7 @@ data Options id = Options {
     logLevel    :: LogLevel
   , logRequest  :: id -> Request -> [Pair]
   , logResponse :: id -> Request -> Response -> Value -> ResponseTime -> [Pair]
+  -- | Build the log line printed before HTTP response is sent
   , logResponseSending :: id -> Request -> [Pair]
   -- | An optional constructor of the response body log value.
   , logBody :: Maybe (Request -> Status -> ResponseHeaders -> Maybe (Builder -> Value))

--- a/src/Network/Wai/Log/Options.hs
+++ b/src/Network/Wai/Log/Options.hs
@@ -36,6 +36,7 @@ data Options id = Options {
     logLevel    :: LogLevel
   , logRequest  :: id -> Request -> [Pair]
   , logResponse :: id -> Request -> Response -> Value -> ResponseTime -> [Pair]
+  , logResponseSending :: id -> Request -> [Pair]
   -- | An optional constructor of the response body log value.
   , logBody :: Maybe (Request -> Status -> ResponseHeaders -> Maybe (Builder -> Value))
   -- | A function for getting the request id
@@ -64,6 +65,7 @@ defaultOptions = Options
   { logLevel = LogInfo
   , logRequest = defaultLogRequest
   , logResponse = defaultLogResponse
+  , logResponseSending = defaultLogResponseSending
   , logBody = Nothing
   , logGetRequestId = const nextRandom
   }
@@ -75,6 +77,7 @@ mkOpaqueDefaultOptions getReqId = Options
   { logLevel = LogInfo
   , logRequest = defaultLogRequest
   , logResponse = defaultLogResponse
+  , logResponseSending = defaultLogResponseSending
   , logBody = Nothing
   , logGetRequestId = getReqId
   }
@@ -120,6 +123,11 @@ defaultLogResponse reqId req resp responseBody time =
   , "full_time" .= full time
   , "elapsed_time" .= processing time
   ]
+
+-- | Just logs the request id
+defaultLogResponseSending :: (ToJSON id) => id -> Request -> [Pair]
+defaultLogResponseSending reqId _req = requestId reqId
+
 
 -- | Helper to consistently log the request id in your application by adding
 -- @request_id@ field to log's 'localData'


### PR DESCRIPTION
We extend the logger `Options` to include a handler field for controlling the 'Sending Response' log line, so arbitrary information from the request can be included. The default option values are extended to provide the established behavior of printing only the request id. This also allows us to remove a hardwired use of the `ToJSON` constraint from `logRequestsWith`.
